### PR TITLE
feat: ui components

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,48 @@
+import styled, { css } from 'styled-components';
+
+type Props = {
+	size? : string;
+  color? : string;
+  background? : string;
+}
+
+
+const giveSize = css<Props>`
+  ${props => props.size ? `${props.size}rem` : '2rem'};
+  `
+
+const halfSize = css<Props>`
+  ${props => props.size ? `${parseInt(props.size) / 2}rem` : '1rem'};
+  `
+
+  const defaultStyle = css<Props>`
+    border-radius: 50%;
+    width: ${giveSize};
+    height: ${giveSize};
+    `
+
+const img = styled.img<Props>`
+  ${defaultStyle};
+  vertical-align: middle;
+`
+
+const txt = styled.div<Props>`
+  ${defaultStyle};
+  font-size: ${halfSize};
+  font-weight: 900;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: ${props => props.background ? `var(${"--" + props.background})` :
+   `var(${"--white"})`};
+  color: ${props => props.color ? `var(${"--" + props.color})` :
+   `var(${"--dark-gray"})`};
+`
+
+const Avatar = {
+  img : img,
+  txt : txt,
+}
+
+export default Avatar;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,43 @@
+import styled, { css } from 'styled-components';
+import { Link } from 'react-router-dom';
+
+type Props = {
+	size? : string;
+  color? : string;
+  background? : string;
+}
+
+const defaultStyle = css<Props>`
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+  padding: 0.25em;
+  border-radius: 0.25em;
+  border: 1px solid;
+  &:hover {
+    transform: scale(1.1, 1.1);
+  }
+  font-size: ${props=> props.size ? `${props.size}rem` : `2rem`};
+  background: ${props => props.background ? `var(${"--" + props.background})` : `inherit`};
+  color: ${props => props.color ? `var(${"--" + props.color})` : `inherit`};
+`
+
+const a = styled.a<Props>`
+  ${defaultStyle}
+`;
+
+const link = styled(Link)<Props>`
+  ${defaultStyle}
+`
+
+const button = styled.button<Props>`
+  ${defaultStyle}
+`
+
+const Button = {
+  button : button,
+  link : link,
+  a : a,
+}
+
+export default Button;


### PR DESCRIPTION
## 요약
재사용성이 높은 UI를 미리 만들어두고,
`
<{Component}.{TAG}
{props}="string" {props}="string">
` 와 같은 방식으로 호출 할 수 있도록 구현했습니다.

## Button
### Example
```
import Button from '...path/Button"
<Button.a
size="2"
color="yellow"
background="purple">Purple</Button.a>
```
### TAG
`Button.a, Button.link, Button.button` Button뒤에 css tag 또는 react-router-dom의 link 같은 타입을 붙여서 사용합니다.
(submit 버튼이 필요할 때 <Button.button>, 다른 페이지 컴포넌트로 이동이 필요할 때 <Button.link>, 외부 페이지 이동이 필요할 때 <Button.a>)
### Props
#### size
설정 하지 않으면 2rem이 됩니다. 1로 설정하면 1rem이 됩니다. 
> rem은 루트(html)의 글꼴 크기를 1로 갖는 단위인데요, 기본적으로 1rem당 16px으로 생각하시면 됩니다!
#### colors
설정하지 않으면 부모 컴포넌트의 색깔을 상속 받습니다. color와 background는 저희가 global style에 작성했던 색 변수(--purple, --yellow)에서 앞의 하이픈을 빼고 쓰도록 구현했습니다. 

![button](https://user-images.githubusercontent.com/86599495/200099835-43e69a0f-9bfb-4299-a584-9bfbb085827b.JPG)

## Avatar
### Example
```
import Avatar from '...path/Avatar'
import img1 from '...path/image.png'
<Avatar.img size="10" src={img1}/>
<Avatar.txt
size="3" background="purple" color="yellow">YOUNG</Avatar.txt>
```
### TAG
img파일과 이미지가 없는 유저를 위해서 text형식도 지원하도록 `.img, .txt` 두가지를 구현했습니다.
### Props
#### size
버튼과 동일한 단위를 가집니다. 2rem이 기본값입니다.
기본적으로 size="1"인 경우에 16px * 16px 사이즈가 됩니다.
#### colors
txt 태그인 경우에만 적용됩니다. 설정하지 않으면 background : black; color:white로 지정해뒀습니다.

#### txt
만약 children의 글자수가 3을 넘어가면 `overflow: hidden` 설정으로 가운데 글자만 보입니다.

![avatar](https://user-images.githubusercontent.com/86599495/200100497-11de516a-9f80-4e4e-8d98-f25e00e32a07.JPG)
