### PR TITLE
20 chat app layout

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,6 +19,7 @@ import GlobalStyle from './GlobalStyle';
 import Profile from "./pages/profile/ProfilePage"
 import Header from './Header';
 import Footer from './Footer';
+import App from './pages/app';
 
 const BasicLayout = () => {
   return (
@@ -41,7 +42,13 @@ const BasicLayout = () => {
           element={
             <RequireAuth>
               <Profile />
-            </RequireAuth >  
+            </RequireAuth >
+          } />
+          <Route path="/chat"
+          element={
+            <RequireAuth>
+              <App />
+            </RequireAuth >
           } />
         </Routes>
       <Footer />

--- a/src/pages/app/components/Chat.tsx
+++ b/src/pages/app/components/Chat.tsx
@@ -1,0 +1,92 @@
+import styled from "styled-components";
+import Avatar from "../../../components/Avatar";
+import Button from "../../../components/Button";
+
+const Container = styled.div`
+	position: relative;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	padding: 1rem;
+	background: var(--dark-gray);
+	overflow-x: hidden;
+`
+
+const HeaderSection = styled.div`
+	width: 100%;
+	flex: 1 10%;
+	display: flex;
+	justify-content: space-between;
+	& > * {
+		background: inherit;
+	}
+`
+
+const ChatContainer = styled.div`
+	width: 100%;
+	flex: 1 90%;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	background: var(--dark-gray);
+	margin-bottom:2.5em;
+`
+
+const OtherChat = styled.div`
+	max-width: 70%;
+	border-radius: 2rem;
+	padding: 1rem;
+	margin: 1rem;
+	background: white;
+	color: black;
+	align-self: flex-start;
+`
+
+const MyChat = styled.div`
+	max-width: 70%;
+	border-radius: 2rem;
+	padding: 1rem;
+	margin: 1rem;
+	background: var(--purple);
+	color: black;
+	align-self: flex-end;
+	text-align: right;
+`
+
+const InputSection = styled.div`
+	display: flex;
+	position: absolute;
+	width: 100%;
+	display:flex;
+	bottom: 0;
+`
+
+const Input = styled.input`
+	width: 90%;
+	border-radius: 1.5rem;
+	background: var(--white);
+	color: var(--dark-gray);
+`
+
+const Chat = ({setIsInfoOn} : any) => {
+	return (
+		<Container>
+			<HeaderSection>
+				<h2>Other, Me</h2>
+				<p onClick={()=>setIsInfoOn(true)}>:</p>
+			</HeaderSection>
+			<ChatContainer>
+				<OtherChat>Other: hi!</OtherChat>
+				<MyChat>Me: hi!</MyChat>
+				<OtherChat>Other: hi!</OtherChat>
+			</ChatContainer>
+			<InputSection>
+				<Input></Input>
+				<Button.button>{">"}</Button.button>
+			</InputSection>
+		</Container>
+	);
+}
+
+export default Chat;

--- a/src/pages/app/components/Home.tsx
+++ b/src/pages/app/components/Home.tsx
@@ -1,0 +1,101 @@
+import styled from "styled-components";
+import Avatar from "../../../components/Avatar";
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-items: flex-start;
+	align-items: center;
+	padding: 1rem;
+	background: var(--dark-gray);
+`
+
+const HeaderSection = styled.div`
+	width: 100%;
+	flex: 1 10%;
+	display: flex;
+	justify-content: space-between;
+`
+
+const ContentSection = styled.div`
+	width: 100%;
+	flex: 1 90%;
+`
+
+const NoticeContainer = styled.div`
+	height: 30%;
+	background: white;
+	padding: 2rem;
+	border-radius: 1rem;
+	margin:2rem;
+
+`
+
+const ChannelContainer = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+`
+
+const ChannelCard = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	justify-content: space-between;
+	background: white;
+	color:black;
+	padding: 2rem;
+	border-radius: 1rem;
+	margin:2rem;
+	& > * {
+		background: inherit;
+		color:inherit;
+	}
+`
+
+const Home = ({setIsInfoOn} : any) => {
+	return (
+		<Container>
+			<HeaderSection>
+				<h2>Welcome, Young il</h2>
+				<p onClick={()=>setIsInfoOn(true)}>:</p>
+			</HeaderSection>
+			<ContentSection>
+				<p>공지사항</p>
+					<NoticeContainer></NoticeContainer>
+				<ChannelContainer>
+					<p>채널목록</p>
+					<ChannelCard>
+						<p>5</p>
+						<h3>트센뽀개기</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						<Avatar.txt background="light-gray" color="white">+3</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>3</p>
+						<h3>프론트엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						<Avatar.txt background="light-gray" color="white">+1</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+				</ChannelContainer>
+			</ContentSection>
+		</Container>
+	);
+}
+
+export default Home;

--- a/src/pages/app/components/Info.tsx
+++ b/src/pages/app/components/Info.tsx
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+import Avatar from "../../../components/Avatar";
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-items: flex-start;
+	align-items: center;
+	padding: 1rem;
+	border-left: 1px solid white;
+	background: var(--dark-gray);
+`
+
+const ControlSection = styled.div`
+	width: 100%;
+	flex: 1 10%;
+	display: flex;
+	justify-content: space-between;
+`
+
+const ProfileSection = styled.div`
+	width: 100%;
+	flex: 1 60%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	`
+
+const IconSection = styled.div`
+	background: var(--light-gray);
+	border-radius: 1rem;
+	width: 100%;
+	flex: 1 30%;
+	display: flex;
+	justify-content: space-evenly;
+	align-items: center;
+`
+
+
+
+const Info = ({setIsInfoOn} : any) => {
+	return (
+		<Container>
+			<ControlSection>
+				<p onClick={()=>setIsInfoOn(false)}>⏪</p>
+				<p>🔧</p>
+			</ControlSection>
+			<ProfileSection>
+				<Avatar.txt size="5">😊</Avatar.txt>
+				<br></br>
+				<p>Young il, Cho</p>
+				<p>🎖️ 100</p>
+			</ProfileSection>
+			<IconSection>
+				<Avatar.txt size="3">❤️</Avatar.txt>
+				<Avatar.txt size="3">🎮</Avatar.txt>
+				<Avatar.txt size="3">❌</Avatar.txt>
+			</IconSection>
+		</Container>
+	)
+}
+
+export default Info;

--- a/src/pages/app/components/Nav.tsx
+++ b/src/pages/app/components/Nav.tsx
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+import Avatar from "../../../components/Avatar";
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	align-items: center;
+	padding: 1rem;
+	border-right: 1px solid white;
+	background: var(--dark-gray);
+`
+
+const IconSection = styled.div`
+	flex: 1 50%;
+	width: 80%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	line-height: 4rem;
+	align-items: center;
+	& > * {
+		font-size: 1rem;
+	}
+`
+
+const Button = styled.div`
+	&:hover {
+		transform: scale(1.5);
+	}
+`
+
+const Nav = ({setLocate} : any) => {
+	return (
+			<Container>
+				<div>LOGO</div>
+				<IconSection>
+					<Button onClick={()=>setLocate("home")}>🏠</Button>
+					<Button onClick={()=>setLocate("dm")}>👨‍👧‍👦</Button>
+					<Button onClick={()=>setLocate("dm")}>🤫</Button>
+				</IconSection>
+				<div>
+				<Avatar.txt>😊</Avatar.txt>
+				</div>
+			</Container>
+	)
+}
+
+export default Nav;

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -1,0 +1,62 @@
+import styled from "styled-components";
+import Nav from "./components/Nav";
+import Info from "./components/Info";
+import Chat from "./components/Chat";
+import Home from "./components/Home";
+import { useState } from "react";
+
+const Wrapper = styled.div`
+	height: 100vh;
+	padding: 4rem;
+	background: var(--light-gray);
+`
+
+const Container = styled.div`
+	height:100%;
+	display: flex;
+	border-radius: 2rem;
+	padding: 1rem;
+`
+
+const NavSection = styled.div`
+	width: 10%;
+	height: 100%;
+`
+
+const MainSection = styled.div`
+	flex: 1 70%;
+	height: 100%;
+	overflow: auto;
+`
+
+const InfoSection = styled.div`
+	flex: 1 20%;
+	height: 100%;
+`
+
+const App = () => {
+	const [locate, setLocate] = useState("home");
+	const [isInfoOn, setIsInfoOn] = useState(true);
+
+	return (
+		<Wrapper>
+			<Container>
+				<NavSection>
+					<Nav setLocate={setLocate}/>
+				</NavSection>
+				<MainSection>
+					{locate === "home" ? <Home setIsInfoOn={setIsInfoOn}></Home>
+					: <></>}
+					{locate === "dm" ? <Chat setIsInfoOn={setIsInfoOn}></Chat> : <></>}
+				</MainSection>
+				{isInfoOn ? <>
+				<InfoSection>
+					<Info setIsInfoOn={setIsInfoOn}/>
+				</InfoSection>
+				</> : <></>}
+			</Container>
+		</Wrapper>
+	);
+}
+
+export default App;


### PR DESCRIPTION
![2](https://user-images.githubusercontent.com/86599495/200342953-df7d1f63-24b7-4c53-b3b6-c50c7a966863.JPG)
![Screenshot 2022-11-07 at 23 59 25](https://user-images.githubusercontent.com/86599495/200342501-089b9cf4-27fb-4461-a6f0-66ec7c22563c.JPG)

우선 기본적인 레이아웃만 구성했습니다. 

채팅과 프로필 컨텐츠는 하드코딩으로 작성했고, 왼쪽에 있는 버튼으로 페이지 이동, ":" 버튼으로 프로필 창 열기, 프로필 컴포넌트 좌측 상단 버튼으로 창 접기까지 구현했습니다.

수요일부터는 지금 헤더랑 푸터가 컴포넌트랑 겹쳐서 임시로 투명 처리해뒀는데 이 부분 고치고, 추가로 접속중인 채널, DM 목록을 보여줄 수 있는 컴포넌트를 추가하겠습니다!

화이팅~~