### PR TITLE
29 chat page layout update

### DIFF
--- a/src/pages/app/components/Detail.tsx
+++ b/src/pages/app/components/Detail.tsx
@@ -1,0 +1,54 @@
+import styled from "styled-components";
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+    padding: 1rem;
+	border-right: 1px solid white;
+	background: var(--dark-gray);
+`
+
+const HeaderSection = styled.div`
+	width: 100%;
+	flex: 0;
+	display: flex;
+	justify-content: space-between;
+	font-family: SBAggroM;
+`
+
+const ChannelSection = styled.div`
+    flex: 8;
+    display: flex;
+    flex-direction: column;
+`
+
+const ChannelCard = styled.div`
+	padding: 2rem;
+	margin: 1rem;
+	border-radius: 1rem;
+	background: white;
+	color: var(--dark-gray);
+`
+
+const Detail = ({setIsDetailOn} : any) => {
+    return (
+        <Container>
+            <HeaderSection>
+                <div>채널목록</div>
+                <div onClick={()=>setIsDetailOn(false)}>{"X"}</div>
+            </HeaderSection>
+            <ChannelSection>
+                <ChannelCard>
+                    트센뽀개기
+                </ChannelCard>
+                <ChannelCard>
+                    프론트엔드
+                </ChannelCard>
+            </ChannelSection>
+        </Container>
+    )
+};
+
+export default Detail

--- a/src/pages/app/components/Home.tsx
+++ b/src/pages/app/components/Home.tsx
@@ -6,39 +6,69 @@ const Container = styled.div`
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	justify-items: flex-start;
-	align-items: center;
 	padding: 1rem;
 	background: var(--dark-gray);
 `
 
 const HeaderSection = styled.div`
 	width: 100%;
-	flex: 1 10%;
+	flex: 0;
 	display: flex;
 	justify-content: space-between;
+	font-family: SBAggroM;
+`
+
+const NoticeSection = styled.div`
+	flex: 3;
+	display: flex;
+	justify-content: flex-start;
+	flex-direction: column;
+	font-family: SBAggroM;
+	margin-top: 1rem;
+`
+
+const NoticeCard = styled.div`
+	padding: 2rem;
+	margin: 2rem;
+	border-radius: 1rem;
+	background: white;
+	color: var(--dark-gray);
 `
 
 const ContentSection = styled.div`
-	width: 100%;
-	flex: 1 90%;
+	flex: 5;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow-y:scroll;
+	&::-webkit-scrollbar{
+		width: 0.5rem;
+	}
+	&::-webkit-scrollbar-thumb{
+		background-color: var(--yellow);
+		border-radius: 10px;    
+	}
+	&::-webkit-scrollbar-track{
+		background-color: rgba(0,0,0,0);
+	}
 `
 
-const NoticeContainer = styled.div`
-	height: 30%;
-	background: white;
-	padding: 2rem;
-	border-radius: 1rem;
-	margin:2rem;
-
+const ContentHeader = styled.h1`
+	flex: 0;
+	display: block;
+	font-family: SBAggroM;
 `
 
 const ChannelContainer = styled.div`
+	flex: 4;
 	display: flex;
 	flex-wrap: wrap;
+	align-items: center;
+
 `
 
 const ChannelCard = styled.div`
+	flex: 15rem;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -46,8 +76,8 @@ const ChannelCard = styled.div`
 	background: white;
 	color:black;
 	padding: 2rem;
+	margin: 1rem;
 	border-radius: 1rem;
-	margin:2rem;
 	& > * {
 		background: inherit;
 		color:inherit;
@@ -58,14 +88,18 @@ const Home = ({setIsInfoOn} : any) => {
 	return (
 		<Container>
 			<HeaderSection>
-				<h2>Welcome, Young il</h2>
+				<h1>Welcome, Young il</h1>
 				<p onClick={()=>setIsInfoOn(true)}>:</p>
 			</HeaderSection>
+			<NoticeSection>
+				<ContentHeader>공지사항</ContentHeader>
+					<NoticeCard>
+						!안녕하세요!안녕하세요!안녕하세요!안녕하세요!안녕하세요!
+					</NoticeCard>
+			</NoticeSection>
 			<ContentSection>
-				<p>공지사항</p>
-					<NoticeContainer></NoticeContainer>
+				<ContentHeader>공개채널</ContentHeader>
 				<ChannelContainer>
-					<p>채널목록</p>
 					<ChannelCard>
 						<p>5</p>
 						<h3>트센뽀개기</h3>
@@ -82,6 +116,142 @@ const Home = ({setIsInfoOn} : any) => {
 						<Avatar.txt background="purple">😊</Avatar.txt>
 						<Avatar.txt background="yellow">🤫</Avatar.txt>
 						<Avatar.txt background="light-gray" color="white">+1</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
+						</div>
+					</ChannelCard>
+					<ChannelCard>
+						<p>2</p>
+						<h3>백엔드</h3>
+						<div>
+						<Avatar.txt background="purple">😊</Avatar.txt>
+						<Avatar.txt background="yellow">🤫</Avatar.txt>
 						</div>
 					</ChannelCard>
 					<ChannelCard>

--- a/src/pages/app/components/Info.tsx
+++ b/src/pages/app/components/Info.tsx
@@ -11,6 +11,7 @@ const Container = styled.div`
 	padding: 1rem;
 	border-left: 1px solid white;
 	background: var(--dark-gray);
+	font-family:NanumSquareL;
 `
 
 const ControlSection = styled.div`

--- a/src/pages/app/components/Nav.tsx
+++ b/src/pages/app/components/Nav.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
 	flex-direction: column;
 	justify-content: space-between;
 	align-items: center;
-	padding: 1rem;
+	padding: 2rem 1rem;
 	border-right: 1px solid white;
 	background: var(--dark-gray);
 `
@@ -22,24 +22,25 @@ const IconSection = styled.div`
 	line-height: 4rem;
 	align-items: center;
 	& > * {
-		font-size: 1rem;
+		font-size: 2rem;
 	}
 `
 
 const Button = styled.div`
+	margin: 1rem 0;
 	&:hover {
 		transform: scale(1.5);
 	}
 `
 
-const Nav = ({setLocate} : any) => {
+const Nav = ({setLocate, setIsDetailOn} : any) => {
 	return (
 			<Container>
 				<div>LOGO</div>
 				<IconSection>
-					<Button onClick={()=>setLocate("home")}>🏠</Button>
-					<Button onClick={()=>setLocate("dm")}>👨‍👧‍👦</Button>
-					<Button onClick={()=>setLocate("dm")}>🤫</Button>
+					<Button onClick={()=>{setLocate("home"); setIsDetailOn(false);}}>🏠</Button>
+					<Button onClick={()=>{setLocate("dm"); setIsDetailOn(true);}}>👨‍👧‍👦</Button>
+					<Button onClick={()=>{setLocate("dm"); setIsDetailOn(true);}}>🤫</Button>
 				</IconSection>
 				<div>
 				<Avatar.txt>😊</Avatar.txt>

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -3,47 +3,60 @@ import Nav from "./components/Nav";
 import Info from "./components/Info";
 import Chat from "./components/Chat";
 import Home from "./components/Home";
+import Detail from "./components/Detail";
 import { useState } from "react";
 
 const Wrapper = styled.div`
+	width: 100vw;
 	height: 100vh;
-	padding: 4rem;
-	background: var(--light-gray);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-image : url("/images/background.jpg");
+	font-family:NanumSquareL;
 `
 
 const Container = styled.div`
-	height:100%;
+	width: 90%;
+	height: 80%;
 	display: flex;
-	border-radius: 2rem;
-	padding: 1rem;
 `
 
 const NavSection = styled.div`
-	width: 10%;
-	height: 100%;
+	flex: 0;
 `
 
 const MainSection = styled.div`
-	flex: 1 70%;
-	height: 100%;
-	overflow: auto;
+	flex: 4;
+	overflow: hidden;
 `
 
 const InfoSection = styled.div`
-	flex: 1 20%;
-	height: 100%;
+	flex: 1.5;
+`
+
+const DetailSection = styled.div`
+	flex: 1.5;
+	background: var(--dark-gray);
 `
 
 const App = () => {
 	const [locate, setLocate] = useState("home");
 	const [isInfoOn, setIsInfoOn] = useState(true);
+	const [isDetailOn, setIsDetailOn] = useState(false);
 
 	return (
 		<Wrapper>
 			<Container>
 				<NavSection>
-					<Nav setLocate={setLocate}/>
+					<Nav setLocate={setLocate} setIsDetailOn={setIsDetailOn}/>
 				</NavSection>
+				{isDetailOn ? <>
+				<DetailSection>
+					<Detail setIsDetailOn={setIsDetailOn}/>
+				</DetailSection>
+				</> : <></>
+				}
 				<MainSection>
 					{locate === "home" ? <Home setIsInfoOn={setIsInfoOn}></Home>
 					: <></>}


### PR DESCRIPTION
기존의 navbar에 있는 아이콘인 👨‍👧‍👦(채널), 🤫(DM)을 클릭 했을 때, navbar 옆에서 유저가 속해 있는 채널목록, DM 혹은 친구목록(미구현)을 표시할 수 있는 Detail 이라는 컴포넌트를 구현했습니다. X키를 눌러서 닫을 수 있고, 안의 내용들은 하드코딩으로 작성했습니다.

추가로 Chat page의 전체 레이아웃과, 🏠(홈화면)을 클릭했을 때 나오게 될 컨텐츠들의 레이아웃을 수정했습니다.

<img width="1672" alt="Screen Shot 2022-11-10 at 5 16 21 PM" src="https://user-images.githubusercontent.com/86599495/201037404-0017a38a-8990-4249-babd-ceb25665e584.png">
