### PR TITLE
update: fix game for divide to in-out and update

### DIFF
--- a/src/pages/game/Constants.ts
+++ b/src/pages/game/Constants.ts
@@ -26,16 +26,19 @@ export namespace Pong {
    }
 
    export enum Game {
-      FPS = 30,
       // Score needed to win
       WINNING_SCORE = 5,
+
+      // Size of canvas
+      CANVAS_WIDTH = 1200,
+      CANVAS_HEIGHT = 600,
 
       // Pixels the players are from the edge
       PLAYER_PADDING = 40,
 
       // Paddle size
       PADDLE_WIDTH = 10,
-      PADDLE_HEIGHT = 50,
+      PADDLE_HEIGHT = 80,
       PADDLE_SPEED = 5,
 
       BALL_SPEED = 2,

--- a/src/pages/game/PongGame.tsx
+++ b/src/pages/game/PongGame.tsx
@@ -7,13 +7,10 @@ import GameEngine from "./lib/GameEngine";
 import Constants from "./Constants";
 
 const BackGround = styled.div`
-  width: 100%;
-  height: 100%;
   min-height: 100vh;
   display: flex;
   overflow: hidden;
-  background-image: url("/images/background.jpg");
-  background-size: cover;
+  background-image: url("/src/images/background.jpg");
 `;
 
 const GameBoard = styled.canvas`
@@ -61,7 +58,7 @@ const PongGame = () => {
   }
 
   return (
-      <GameBoard ref={canvasRef} width={Constants.Game.CANVAS_WIDTH} height={Constants.Game.CANVAS_WIDTH}></GameBoard>
+      <GameBoard ref={canvasRef} width={Constants.Game.CANVAS_WIDTH} height={Constants.Game.CANVAS_HEIGHT}></GameBoard>
   );
 }
 

--- a/src/pages/game/PongGame.tsx
+++ b/src/pages/game/PongGame.tsx
@@ -1,26 +1,35 @@
-import { filterProps } from "framer-motion";
-import {useRef, useState, useEffect} from "react";
+import {useRef, useState, useEffect } from "react";
 import styled from 'styled-components';
 
 import ErrorPage from "../../ErrorPage";
 
-import Constants from "./Constants";
 import GameEngine from "./lib/GameEngine";
+import Constants from "./Constants";
+
+const BackGround = styled.div`
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
+  display: flex;
+  overflow: hidden;
+  background-image: url("/images/background.jpg");
+  background-size: cover;
+`;
 
 const GameBoard = styled.canvas`
-  width: 1200px;
-  height: 600px;
+  width : 80%;
+  height : width / 2;
   position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left:-600px;
-  margin-top:-300px;
+  top:0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin:auto;
 `;
 
 const PongGame = () => {
   const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
   const [ctx, setCtx] = useState<CanvasRenderingContext2D | null>(null);
-
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -28,32 +37,40 @@ const PongGame = () => {
     const canvas = canvasRef.current;
     setCanvas(canvas);
     setCtx(canvas.getContext("2d"));
-  }, [])
+  }, []);
 
-  if (ctx !== null) {
+  if (ctx !== null && canvas !== null) {
     let game = new GameEngine(ctx);
+    console.log(window.innerHeight);
+    console.log(window.innerWidth);
 
-    setInterval(() => {
+    let startTime: number = Date.now();
+    const callback = (timestamp: number) => {
+      let deltaTime = (timestamp - startTime) * 0.06;
+
       game.getInput();
-      game.update();
+      game.update(deltaTime);
       game.draw();
-    }, 1000 / Constants.Game.FPS / 2);
+
+      startTime = timestamp;
+      requestAnimationFrame(callback);
+    };
+    requestAnimationFrame(callback);
   } else {
     <ErrorPage/>
   }
 
-
   return (
-    <>
-      <GameBoard ref={canvasRef} width={1200} height={600}></GameBoard>
-    </>
+      <GameBoard ref={canvasRef} width={Constants.Game.CANVAS_WIDTH} height={Constants.Game.CANVAS_WIDTH}></GameBoard>
   );
 }
 
 const GamePage = () => {
 
   return (
-    <PongGame/>
+    <BackGround>
+      <PongGame/>
+    </BackGround>
   );
 }
 

--- a/src/pages/game/lib/GameEngine.ts
+++ b/src/pages/game/lib/GameEngine.ts
@@ -19,8 +19,8 @@ namespace Pong {
       this.scene.draw();
     }
 
-    update() {
-      this.scene.update();
+    update(deltaTime: number) {
+      this.scene.update(deltaTime);
     }
 
     getInput() {
@@ -38,7 +38,6 @@ namespace Pong {
       if (params === undefined) {
         params = {};
       }
-
       this.scene.load(params);
     }
   }

--- a/src/pages/game/lib/GraphicalElement.ts
+++ b/src/pages/game/lib/GraphicalElement.ts
@@ -1,6 +1,8 @@
 interface GraphicalElement {
   draw: (ctx: CanvasRenderingContext2D) => void;
-  update: (ctx: CanvasRenderingContext2D) => void;
+  update: (deltaTime: number) => void;
   x: number;
   y: number;
 }
+
+export default GraphicalElement;

--- a/src/pages/game/lib/Scene.ts
+++ b/src/pages/game/lib/Scene.ts
@@ -10,7 +10,7 @@ namespace Pong {
 
     // Must be implemented
     abstract draw(): void;
-    abstract update(): void;
+    abstract update(deltaTime: number): void;
     abstract getInput(): void;
 
     // Optionally implement

--- a/src/pages/game/objects/Ball.ts
+++ b/src/pages/game/objects/Ball.ts
@@ -1,4 +1,5 @@
 import Constants from "../Constants";
+import GraphicalElement from "../lib/GraphicalElement";
 
 export namespace Pong {
 
@@ -36,25 +37,23 @@ export namespace Pong {
       }
     }
 
-    update(ctx: CanvasRenderingContext2D) {
-      if (ctx !== undefined) {
-        let maxX = ctx.canvas.width;
-        let maxY = ctx.canvas.height;
+    update(deltaTime: number) {
+      let maxX: number = Constants.Game.CANVAS_WIDTH;
+      let maxY: number = Constants.Game.CANVAS_HEIGHT;
 
-        // ball moving
-        this.x += this.dx * this.speed;
-        this.y += this.dy * this.speed;
+      // ball moving
+      this.x += this.dx * this.speed * deltaTime;
+      this.y += this.dy * this.speed * deltaTime;
 
-        // ball hit wall
-        if (this.x >= maxX || this.x <= 0) {
-          this.destroyed = true;
-          this.dx = 0;
-          this.dy = 0;
-        }
+      // ball hit wall
+      if (this.x >= maxX || this.x <= 0) {
+        this.destroyed = true;
+        this.dx = 0;
+        this.dy = 0;
+      }
 
-        if (this.y >= maxY || this.y <= 0) {
-          this.dy = -this.dy
-        }
+      if (this.y >= maxY || this.y <= 0) {
+        this.dy = -this.dy
       }
     }
 

--- a/src/pages/game/objects/HumanPlayer.ts
+++ b/src/pages/game/objects/HumanPlayer.ts
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Utils from "../lib/Utils";
 import Player from "./Player"
 import { Direction } from "../lib/Directions";
@@ -8,7 +6,6 @@ export namespace Pong {
   export class HumanPlayer extends Player {
 
     private handleKeydown = (evt: KeyboardEvent) => {
-      console.log(evt.key);
       switch (evt.key) {
         case Utils.KeyCode.UP_ARROW:
           this.direction = Direction.UP;

--- a/src/pages/game/objects/Player.ts
+++ b/src/pages/game/objects/Player.ts
@@ -2,6 +2,7 @@ import Constants from "../Constants";
 import Ball from "./Ball";
 import Utils from "../lib/Utils";
 import { Direction } from "../lib/Directions";
+import GraphicalElement from "../lib/GraphicalElement";
 
 export namespace Pong {
 
@@ -36,19 +37,22 @@ export namespace Pong {
       this.score = 0;
     }
 
-    update(ctx: CanvasRenderingContext2D) {
+    getInput() {
 
+    }
+
+    update(deltaTime: number) {
       if (this.direction !== null) {
         switch (this.direction) {
           case Direction.UP:
-            this.y -= this.speed;
+            this.y -= this.speed * deltaTime;
             break;
           case Direction.DOWN:
-            this.y += this.speed;
+            this.y += this.speed * deltaTime;
         }
       }
 
-      let maxY = ctx.canvas.height - this.paddleHeight;
+      let maxY = Constants.Game.CANVAS_HEIGHT - this.paddleHeight;
       if (this.y < 0) {
         this.y = 0;
       } else if (this.y > maxY) {

--- a/src/pages/game/scene/Mainscene.ts
+++ b/src/pages/game/scene/Mainscene.ts
@@ -4,6 +4,7 @@ import Ball from "../objects/Ball";
 import Player from "../objects/Player";
 import HumanPlayer from "../objects/HumanPlayer"
 import EndScene from "./EndScene";
+import GraphicalElement from "../lib/GraphicalElement"
 
 namespace Pong {
   export class MainScene extends Scene {
@@ -85,7 +86,7 @@ namespace Pong {
       this.player1.unbind();
     }
 
-    update() {
+    update(deltaTime: number) {
       if (this.ball.isDestroyed()) {
         if (this.ball.x <= 0) {
           this.player2.givePoint();
@@ -101,7 +102,7 @@ namespace Pong {
         this.gameContext.loadScene(new EndScene(this.ctx, this.player2), { winner: this.player2 });
       } else {
         // Draw remaining objects
-        this.objectsInScene.forEach(object => object.update(this.ctx));
+        this.objectsInScene.forEach(object => object.update(deltaTime));
       }
     }
 

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -13,7 +13,7 @@ const BackGround = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-image : url("/images/background.jpg");
+  background-image : url("/src/images/background.jpg");
 `;
 
 const Layout = styled.div`

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -9,10 +9,11 @@ import LoadingPage from "../../LoadingPage";
 import UserProfile from "./UserProfile";
 
 const BackGround = styled.div`
-  width : 100%;
-  height: 100%;
-  margin-top: 60px;
-  background-image : url("/src/images/background.jpg");
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image : url("/images/background.jpg");
 `;
 
 const Layout = styled.div`


### PR DESCRIPTION
퐁 게임의 다음 부분을 업데이트했습니다.
 - 퐁 게임의 반복 루프를 `setTimeOut`에서 `requestAnimationFrame`으로 변경하였습니다. 이제 60프레임의 고정된 반복을 실시합니다.
 - 이제 퐁 게임의 `update`부분이 `deltaTime`을 사용합니다. 프레임이 달라짐에 따라 발생할 수 있는 게임 속도 문제를 해결했습니다.
 - 퐁 게임의 update 중 `CanvasRenderingContext2D`를 사용하는 부분을 변경하였습니다.
   - 이제 `CanvasRenderingContext2D`에서 가져온 캔버스의 크기가 아니라, `Constants`에 선언해 둔 캔버스의 내부 크기를 사용합니다.
 - 캔버스의 외부 크기가 화면의 좌우 사이즈에 맞게끔 동적으로 변경되도록 하였습니다.

게임 화면의 배경에 배경 이미지를 적용했습니다. 프로필 화면의 배경 이미지도 동일한 방식으로 적용하게끔 변경하였습니다.