### PR TITLE
chat page input proto

### DIFF
--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -5,6 +5,7 @@ type dynamicColor = {
 }
 
 const Wrapper = styled.div<dynamicColor>`
+  position: sticky;
   width: 100%;
   display: flex;
   justify-content: space-between;

--- a/src/pages/social/components/Chat.tsx
+++ b/src/pages/social/components/Chat.tsx
@@ -1,75 +1,137 @@
 import styled from "styled-components";
 import SectionHeader from "../../../components/SectionHeader";
+import ChatInput from "./ChatInput";
+import ChatCard from "./ChatCard";
+import { useEffect, useRef, useState } from "react";
 
 const Container = styled.div`
-	position: relative;
-	width: 100%;
-	height: 100%;
-	display: flex;
-	flex-direction: column;
-	background: var(--dark-gray);
-	overflow-x: hidden;
-`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--dark-gray);
+`;
+
+const ChatSection = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--yellow);
+    border-radius: 10px;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: rgba(0, 0, 0, 0);
+  }
+`;
 
 const ChatContainer = styled.div`
-	width: 100%;
-	flex: 9;
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-end;
-	background: var(--dark-gray);
-`
-
-const OtherChat = styled.div`
-	max-width: 70%;
-	border-radius: 2rem;
-	padding: 1rem;
-	margin: 1rem;
-	background: white;
-	color: black;
-	align-self: flex-start;
-`
-
-const MyChat = styled.div`
-	max-width: 70%;
-	border-radius: 2rem;
-	padding: 1rem;
-	margin: 1rem;
-	background: var(--purple);
-	color: black;
-	align-self: flex-end;
-	text-align: right;
-`
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  background: var(--dark-gray);
+`;
 
 const InputSection = styled.div`
-	display: flex;
-	width: 100%;
-`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 1rem;
+  gap: 0.5rem;
+`;
 
-const Input = styled.input`
-	width: 100%;
-	padding: 1rem;
-	border-radius: 1.5rem;
-	background: var(--white);
-	color: var(--dark-gray);
-`
+type Message = {
+	sender: string,
+	time: string,
+	chat: string,
+};
 
-const Chat = ({setIsInfoOn} : any) => {
-	return (
-		<Container>
-			<SectionHeader color='var(--purple)' title="other, me">
-				<div onClick={()=>setIsInfoOn(true)}>{":"}</div>
-			</SectionHeader>
-			<ChatContainer>
-				<OtherChat>Other: hi!</OtherChat>
-				<MyChat>Me: hi!</MyChat>
-				<OtherChat>Other: hi!</OtherChat>
-			</ChatContainer>
-			<InputSection>
-				<Input></Input>
-			</InputSection>
-		</Container>
-	);
-}
+const DummyMessages: Message[] = [
+  {
+    sender: "other",
+    time: "2022-11-11 11:11",
+    chat: "테스트",
+  },
+  {
+    sender: "young-ch",
+    time: "2022-11-11 11:12",
+    chat: "테스트",
+  },
+  {
+    sender: "young-ch",
+    time: "2022-11-11 11:12",
+    chat: "테스트",
+  },
+  {
+    sender: "young-ch",
+    time: "2022-11-11 11:12",
+    chat: "테스트",
+  },
+  {
+    sender: "other",
+    time: "2022-11-11 11:13",
+    chat: "테스트",
+  },
+  {
+    sender: "other",
+    time: "2022-11-11 11:14",
+    chat: "테스트",
+  },
+  {
+    sender: "other",
+    time: "2022-11-11 11:14",
+    chat: "테스트",
+  },
+];
+
+const Chat = ({ setIsInfoOn } : any) => {
+  const [userMessage, setUserMessage] = useState(null);
+  const lastChat = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    lastChat?.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "end",
+      inline: "nearest",
+    });
+    console.log(userMessage);
+	if (userMessage)
+		DummyMessages.push(userMessage);
+    return setUserMessage(null);
+  }, [userMessage]);
+
+  return (
+    <Container>
+      <SectionHeader color="var(--purple)" title="other, me">
+        <div onClick={() => setIsInfoOn(true)}>{":"}</div>
+      </SectionHeader>
+      <ChatSection>
+        <ChatContainer ref={lastChat}>
+          {DummyMessages.map((ele, idx) => {
+            const { sender, time, chat } = ele;
+            const isMe = (sender == "young-ch") ? true : false;
+            return (
+              <ChatCard
+                key={idx}
+                isMe={isMe}
+                sender={sender}
+                time={time}
+                chat={chat}
+              ></ChatCard>
+            );
+          })}
+        </ChatContainer>
+      </ChatSection>
+      <InputSection>
+        <ChatInput setUserMessage={setUserMessage}></ChatInput>
+      </InputSection>
+    </Container>
+  );
+};
 
 export default Chat;

--- a/src/pages/social/components/ChatCard.tsx
+++ b/src/pages/social/components/ChatCard.tsx
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+import Avatar from "../../../components/Avatar";
+
+type Props = {
+  isMe: boolean;
+  sender?: string;
+  time?: string;
+  chat?: string;
+};
+
+const Container = styled.div<Props>`
+  max-width: 70%;
+  display: flex;
+  flex-direction: ${(props) => (props.isMe ? `row-reverse` : `row`)};
+  align-self: ${(props) => (props.isMe ? `flex-end` : `flex-start`)};
+`;
+
+const Sender = styled.div``;
+
+const MessageContainer = styled.div<Props>`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: ${(props) => (props.isMe ? `flex-end` : `flex-start`)};
+  margin-left: ${(props) => (props.isMe ? `` : `1rem`)};
+`;
+
+const Message = styled.div<Props>`
+  padding: 1rem;
+  margin-top: 1rem;
+  background: ${(props) => (props.isMe ? `var(--purple)` : `var(--white)`)};
+  color: black;
+  display: flex;
+`;
+
+const TimeBar = styled.div`
+  margin-top: 1rem;
+  align-self: flex-end;
+`;
+
+const ChatCard = ({ isMe, sender, time, chat }: Props) => {
+  return (
+    <Container isMe={isMe}>
+      {!isMe ? (
+        <Sender>
+          <Avatar.txt>{sender}</Avatar.txt>
+        </Sender>
+      ) : null}
+      <MessageContainer isMe={isMe}>
+        <Message isMe={isMe}>{chat}</Message>
+        <TimeBar>{time}</TimeBar>
+      </MessageContainer>
+    </Container>
+  );
+};
+
+export default ChatCard;

--- a/src/pages/social/components/ChatInput.tsx
+++ b/src/pages/social/components/ChatInput.tsx
@@ -1,0 +1,60 @@
+import styled from "styled-components"
+import { useRef } from "react"
+
+const Input = styled.input`
+	flex: 9;
+	padding: 1rem;
+	background: var(--white);
+	color: var(--dark-gray);
+`
+
+const Label = styled.label`
+	flex: 1;
+	display: flex;
+	align-items:center;
+	justify-content:center;
+	padding: 1rem;
+	background: var(--yellow);
+	color: var(--dark-gray);
+	border-radius: 8px;
+`
+
+const ChatInput = ({setUserMessage} : any) => {
+    const ref = useRef<HTMLInputElement>(null);
+
+	const getTime = () => {
+		let time = new Date();   
+		let dateLine = time.toLocaleDateString("ko-KR");
+		let timeLine = time.toLocaleTimeString("ko-KR");
+		return (dateLine + ' ' + timeLine);
+	}
+
+	const sendUserInput = () => {
+		const userInput = ref?.current?.value;
+		if (ref?.current?.value) {
+			ref.current.value = "";
+			setUserMessage({sender: "young-ch", time: getTime(), chat: userInput});
+		}
+	}
+
+    const onClickHandler = (event : any) => {
+		event.preventDefault();
+		sendUserInput();
+    }
+
+	const onKeyPressHandler = (event: any) => {
+        if(event.key === 'Enter') {
+			const userInput = ref?.current?.value;
+			sendUserInput();
+		}
+    }
+
+    return (
+      <>
+        <Input ref={ref} type="text" id="message" placeholder="" onKeyPress={onKeyPressHandler}></Input>
+        <Label htmlFor="message" onClick={onClickHandler}>SEND</Label>
+      </>
+  )
+}
+
+export default ChatInput


### PR DESCRIPTION
<img width="1363" alt="Screen Shot 2022-11-16 at 7 23 57 PM" src="https://user-images.githubusercontent.com/86599495/202156720-08dfc5ef-36dc-45f5-a3c1-37abacfa0dc5.png">


* 채팅 내용이 많아져서 스크롤을 해야 할 때 SectionHeader가 함께 내려가는 현상이 있어서 해당 컴포넌트에 `position: sticky;` 옵션을 추가했습니다.
* 기존에 하드코딩으로 작성했던 채팅 페이지를 수정했습니다.
* Chat.tsx 파일안에 DummyMessages라는 배열을 임시로 만들어두고, map함수를 이용해서 채팅 내용을 출력하도록 했습니다.
```
  {
    sender: "other",
    time: "2022-11-11 11:11",
    chat: "테스트",
  },,,,
```
* input 부분의 레이아웃을 수정하고 내용을 입력하면 DummyMessages 배열 뒤에 붙도록 구현했습니다.
* 채팅방에 처음 접속할 때, 메세지를 입력한 직후 최근 메세지를 볼 수 있도록 스크롤을 가장 밑으로 내리는 기능을 구현했습니다.