### PR TITLE
Private Page

### DIFF
--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import PlayerInfo from "./PlayerInfo";
+import PlayerInfo from "../pages/lobby/components/PlayerInfo";
 
 type DynamicColor = {
 	color: string;
@@ -59,22 +59,22 @@ const PlayerCard = (props: {type: string, player: PlayerInfo}) => {
 			case "purple":	
 				return (
 					<CardWrapper color="--purple">
-						<ProfileImg src={props.player.image} size="100px"/>
+						<ProfileImg src={props.player.profile_url} size="100px"/>
 						<NicknameText>{props.player.nickname}</NicknameText>
-						<IntraText color="--light-light-gray">{props.player.intra}</IntraText>
+						<IntraText color="--light-light-gray">{props.player.intra_id}</IntraText>
 					</CardWrapper>
 				);
 			case "yellow":
 				return (
 					<CardWrapper color="--yellow">
-						<ProfileImg src={props.player.image} size="100px"/>
+						<ProfileImg src={props.player.profile_url} size="100px"/>
 						<NicknameText>{props.player.nickname}</NicknameText>
-						<IntraText color="--light-gray">{props.player.intra}</IntraText>
+						<IntraText color="--light-gray">{props.player.intra_id}</IntraText>
 					</CardWrapper>
 				);
 			case "spectator":
 				return (
-					<SpectatorCard>{props.player.intra}</SpectatorCard>
+					<SpectatorCard>{props.player.intra_id}</SpectatorCard>
 				);
 		} 
 	}

--- a/src/components/SimpleCard.tsx
+++ b/src/components/SimpleCard.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components"
+
+const Wrapper = styled.div`
+	width: 100%;
+	padding: 1rem;
+`
+
+const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	background: var(--white);
+	color: var(--dark-gray);
+	gap: 1rem;
+	padding: 1rem;
+	border-radius: 1rem;
+`
+
+const Text = styled.div`
+	font-size: 1.5rem;
+`
+const SimpleCard = ({text}: {text: string}) => {
+  return (
+    <Wrapper>
+      <Container>
+				<Text>
+					{text ? text : "No Content"}
+				</Text>
+      </Container>
+    </Wrapper>
+  )
+}
+
+export default SimpleCard;

--- a/src/pages/arcade/scene/EndScene.ts
+++ b/src/pages/arcade/scene/EndScene.ts
@@ -37,7 +37,7 @@ export namespace Pong {
       }).then (response => {
         console.log("set arcade score: " + response.status);
       }).catch (error => {
-        alert('score update failed');
+        console.error('score update failed');
       });
     }
 

--- a/src/pages/game/PongGame.tsx
+++ b/src/pages/game/PongGame.tsx
@@ -9,7 +9,6 @@ import GameEngine from "./lib/GameEngine";
 import PongIO from "./lib/IO";
 import Constants from "./Constants";
 
-
 const BackGround = styled.div`
   min-height: 100vh;
   display: flex;
@@ -20,14 +19,12 @@ const BackGround = styled.div`
 const GameBoard = styled.canvas`
   width : 80%;
   height : width / 2;
-  position: absolute;
   top:0;
   bottom: 0;
   left: 0;
   right: 0;
   margin:auto;
 `;
-
 
 export const PongGame = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -46,7 +43,7 @@ export const PongGame = () => {
     }
   }, [canvasRef.current, socket]);
 
-  
+
   useEffect(() => {
     if (socket) {
       socket.on("draw", (data: PongIO.GameRecvData) => {

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -31,7 +31,7 @@ const Home = () => {
 			<Wrapper>
         <ImageCard text={"Private"} imagePath={"/images/lock.png"} imagePadding="15px" routePath={"/matching"}/>
         <ImageCard text={"Public"} imagePath={"/images/earth.png"} imagePadding="25px" routePath={"/lobby"}/>
-        <ImageCard text={"Arcade"} imagePath={"/images/controller.png"} imagePadding="15px" routePath={"/matching"}/>
+        <ImageCard text={"Arcade"} imagePath={"/images/controller.png"} imagePadding="15px" routePath={"/arcade"}/>
         <ImageCard text={"Ladder"} imagePath={"/images/trophy.png"} imagePadding="15px" routePath={"/matching"}/>
         <ImageCard text={"Social"} imagePath={"/images/chat.png"} imagePadding="20px" routePath={"/social"}/>
 			</Wrapper>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -29,7 +29,7 @@ const Home = () => {
 	return (
 		<Layout>
 			<Wrapper>
-        <ImageCard text={"Private"} imagePath={"/images/lock.png"} imagePadding="15px" routePath={"/matching"}/>
+        <ImageCard text={"Private"} imagePath={"/images/lock.png"} imagePadding="15px" routePath={"/private"}/>
         <ImageCard text={"Public"} imagePath={"/images/earth.png"} imagePadding="25px" routePath={"/lobby"}/>
         <ImageCard text={"Arcade"} imagePath={"/images/controller.png"} imagePadding="15px" routePath={"/arcade"}/>
         <ImageCard text={"Ladder"} imagePath={"/images/trophy.png"} imagePadding="15px" routePath={"/matching"}/>

--- a/src/pages/lobby/components/GameInfo.tsx
+++ b/src/pages/lobby/components/GameInfo.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { motion } from 'framer-motion';
 import styled from "styled-components";
-import CardWrapper from "./PlayerCard";
+import CardWrapper from "../../../components/PlayerCard";
 import PlayerInfo from "./PlayerInfo";
 import SectionHeader from "../../../components/SectionHeader";
 

--- a/src/pages/lobby/components/GameInfo.tsx
+++ b/src/pages/lobby/components/GameInfo.tsx
@@ -89,12 +89,12 @@ const GameInfo = ({setInfo, setLocate, title} : any) => {
   let playerList = new Array<PlayerInfo>();
 	let spectatorList = new Array<PlayerInfo>();
 
-	playerList.push(new PlayerInfo("sunhkim", "sunhkim", "some link"));
-	playerList.push(new PlayerInfo("yoahn", "yoahn", "some link"));
+	playerList.push(new PlayerInfo("sunhkim", "mocha-kim", "/src/images/earth.jpg", 1500, true));
+	playerList.push(new PlayerInfo("yoahn", "yoahn", "/src/images/game.jpg", 1200, true));
 
-	spectatorList.push(new PlayerInfo("seonhjeo", "seonhjeo", "some link"))
-	spectatorList.push(new PlayerInfo("chanhuil", "chanhuil", "some link"))
-	spectatorList.push(new PlayerInfo("young-ch", "young-ch", "some link"))
+	spectatorList.push(new PlayerInfo("seonhjeo", "seonhjeo", "some link", 1500, true))
+	spectatorList.push(new PlayerInfo("chanhuil", "chanhuil", "some link", 1600, false))
+	spectatorList.push(new PlayerInfo("young-ch", "young-ch", "some link", 1600, false))
 
 	const enterLobby = () => {
 		setLocate("lobby");

--- a/src/pages/lobby/components/GameList.tsx
+++ b/src/pages/lobby/components/GameList.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import SectionHeader from "../../../components/SectionHeader";
+import SimpleCard from "../../../components/SimpleCard";
 import GameCard from "./GameCard";
 
 const Container = styled.div`
@@ -15,8 +16,8 @@ const NoticeSection = styled.div`
 	display: flex;
 	justify-content: flex-start;
 	flex-direction: column;
-	font-family: SBAggroM;
-	margin-top: 1rem;
+	font-family: NanumSquareB;
+	margin-right: 0.5rem;
 `
 
 const ChannelSection = styled.div`
@@ -61,6 +62,7 @@ const GameList = ({toggleInfo, setTitle} : any) => {
 			<SectionHeader color='var(--purple)' title="Welcome to Pong Game World!"/>
 			<ContentHeader>공지사항</ContentHeader>
 			<NoticeSection>
+				<SimpleCard text="매너있는 플레이 부탁드립니다."/>
 			</NoticeSection>
 			<ContentHeader>공개채널</ContentHeader>
 			<ChannelSection>

--- a/src/pages/lobby/components/GameRoom.tsx
+++ b/src/pages/lobby/components/GameRoom.tsx
@@ -91,12 +91,12 @@ const GameRoom = ({setLocate, title} : any) => {
   let playerList = new Array<PlayerInfo>();
 	let spectatorList = new Array<PlayerInfo>();
 
-	playerList.push(new PlayerInfo("sunhkim", "mocha-kim", "/src/images/earth.jpg"));
-	playerList.push(new PlayerInfo("yoahn", "yoahn", "/src/images/game.jpg"));
+	playerList.push(new PlayerInfo("sunhkim", "mocha-kim", "/src/images/earth.jpg", 1500, true));
+	playerList.push(new PlayerInfo("yoahn", "yoahn", "/src/images/game.jpg", 1200, true));
 
-	spectatorList.push(new PlayerInfo("seonhjeo", "seonhjeo", "some link"))
-	spectatorList.push(new PlayerInfo("chanhuil", "chanhuil", "some link"))
-	spectatorList.push(new PlayerInfo("young-ch", "young-ch", "some link"))
+	spectatorList.push(new PlayerInfo("seonhjeo", "seonhjeo", "some link", 1500, true))
+	spectatorList.push(new PlayerInfo("chanhuil", "chanhuil", "some link", 1600, false))
+	spectatorList.push(new PlayerInfo("young-ch", "young-ch", "some link", 1600, false))
 
 	return (
 		<Container>

--- a/src/pages/lobby/components/GameRoom.tsx
+++ b/src/pages/lobby/components/GameRoom.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import SectionHeader from "../../../components/SectionHeader";
+import { PongGame } from "../../game/PongGame";
 import PlayerCard from "./PlayerCard";
 
 const Container = styled.div`
@@ -75,6 +76,16 @@ const ContentHeader = styled.div`
 	text-shadow: 0 2px 0 black;
 `;
 
+const GameContainer = styled.div`
+	border-width: 1px;
+	border-style: solid hidden hidden hidden;
+	background: var(--light-gray);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+`;
+
 class Player {
   intra: string;
   nickname: string;
@@ -118,7 +129,9 @@ const GameRoom = ({setLocate, title} : any) => {
 					}
 				</SpectatorContainer>
 			</UserInfoContainer>
-			{/* <GameWindow /> */}
+			<GameContainer>
+				<PongGame />
+			</GameContainer>
 		</Container>
 	);
 }

--- a/src/pages/lobby/components/PlayerInfo.ts
+++ b/src/pages/lobby/components/PlayerInfo.ts
@@ -1,12 +1,14 @@
 class PlayerInfo {
-  intra: string;
+  intra_id: string;
   nickname: string;
-  image: string;
+  profile_url: string;
+  ladder_score?: number;
 
-  constructor(i: string, n: string, img: string) {
-    this.intra = i;
+  constructor(i: string, n: string, img: string, ladder_score?: number) {
+    this.intra_id = i;
 		this.nickname = n;
-		this.image = img;
+		this.profile_url = img;
+    this.ladder_score = ladder_score;
   }
 }
 

--- a/src/pages/lobby/components/PlayerInfo.ts
+++ b/src/pages/lobby/components/PlayerInfo.ts
@@ -2,13 +2,15 @@ class PlayerInfo {
   intra_id: string;
   nickname: string;
   profile_url: string;
-  ladder_score?: number;
+  ladder_score: number;
+  is_my_friend: boolean;
 
-  constructor(i: string, n: string, img: string, ladder_score?: number) {
+  constructor(i: string, n: string, img: string, ladder_score: number, is_my_friend: boolean) {
     this.intra_id = i;
 		this.nickname = n;
 		this.profile_url = img;
     this.ladder_score = ladder_score;
+    this.is_my_friend = is_my_friend;
   }
 }
 

--- a/src/pages/private/components/FriendCard.tsx
+++ b/src/pages/private/components/FriendCard.tsx
@@ -1,0 +1,64 @@
+import axios from "axios"
+import styled from "styled-components"
+import { Url } from "../../../constants/Global"
+import { useAuthState } from "../../../context/AuthHooks"
+import { UserProps } from "../../profile/UserProps"
+
+const Wrapper = styled.div`
+  width: 100%;
+  padding: 1rem;
+`
+
+const Container = styled.div`
+  display: flex;
+  background: var(--white);
+  color: var(--dark-gray);
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  &:hover {
+		border: solid 1px var(--light-gray);
+  }
+`
+
+const Nickname = styled.div`
+	font-size: 1.5rem;
+`
+
+const Intra = styled.div`
+	font-size: 1.5rem;
+`
+
+const FriendCard = ({nickname, intra, setData, setIsInfoOn}: {nickname: string, intra: string, setData: any, setIsInfoOn: any}) => {
+  const { token } = useAuthState();
+
+  const showInfo = async () => {
+    await axios.get(Url + 'user/profile/' + intra, {
+      headers: {
+        Authorization:"Bearer " + token
+      }
+    }).then(response => {
+      if (response.data) {
+        const data: UserProps = response.data;
+        console.log(data);
+        setIsInfoOn(true);
+      } else {
+        console.error('There is no user named ' + intra);
+        setData(null);
+      }
+    }).catch(error => {
+      console.error(intra + ' profile loading failed');
+    });
+  }
+
+  return (
+    <Wrapper onClick={showInfo}>
+      <Container>
+				<Nickname>{nickname}</Nickname>
+				<Intra>{intra}</Intra>
+      </Container>
+    </Wrapper>
+  )
+}
+
+export default FriendCard;

--- a/src/pages/private/components/FriendCard.tsx
+++ b/src/pages/private/components/FriendCard.tsx
@@ -29,30 +29,9 @@ const Intra = styled.div`
 	font-size: 1.5rem;
 `
 
-const FriendCard = ({nickname, intra, setData, setIsInfoOn}: {nickname: string, intra: string, setData: any, setIsInfoOn: any}) => {
-  const { token } = useAuthState();
-
-  const showInfo = async () => {
-    await axios.get(Url + 'user/profile/' + intra, {
-      headers: {
-        Authorization:"Bearer " + token
-      }
-    }).then(response => {
-      if (response.data) {
-        const data: UserProps = response.data;
-        console.log(data);
-        setIsInfoOn(true);
-      } else {
-        console.error('There is no user named ' + intra);
-        setData(null);
-      }
-    }).catch(error => {
-      console.error(intra + ' profile loading failed');
-    });
-  }
-
+const FriendCard = ({nickname, intra, setIsInfoOn}: {nickname: string, intra: string, setIsInfoOn: any}) => {
   return (
-    <Wrapper onClick={showInfo}>
+    <Wrapper onClick={() => setIsInfoOn(true)}>
       <Container>
 				<Nickname>{nickname}</Nickname>
 				<Intra>{intra}</Intra>

--- a/src/pages/private/components/FriendCard.tsx
+++ b/src/pages/private/components/FriendCard.tsx
@@ -6,7 +6,7 @@ import { UserProps } from "../../profile/UserProps"
 
 const Wrapper = styled.div`
   width: 100%;
-  padding: 1rem;
+  padding: 1rem 1rem 0;
 `
 
 const Container = styled.div`
@@ -29,9 +29,14 @@ const Intra = styled.div`
 	font-size: 1.5rem;
 `
 
-const FriendCard = ({nickname, intra, setIsInfoOn}: {nickname: string, intra: string, setIsInfoOn: any}) => {
-  return (
-    <Wrapper onClick={() => setIsInfoOn(true)}>
+const FriendCard = ({nickname, intra, setIsInfoOn, setInfoIntra}: {nickname: string, intra: string, setIsInfoOn: any, setInfoIntra: any}) => {
+  const onClick = () => {
+		setInfoIntra(intra);
+		setIsInfoOn(true);
+	}
+	
+	return (
+    <Wrapper onClick={onClick}>
       <Container>
 				<Nickname>{nickname}</Nickname>
 				<Intra>{intra}</Intra>

--- a/src/pages/private/components/FriendsList.tsx
+++ b/src/pages/private/components/FriendsList.tsx
@@ -70,9 +70,8 @@ const dummyFriends: PlayerInfo[] = [
 	},
 ]
 
-const FriendsList = ({setIsInfoOn, setData} : any) => {
+const FriendsList = ({setIsInfoOn} : any) => {
   let onlineFriends = new Array<PlayerInfo>();
-
 	const { token } = useAuthState();
 
   const getFriends = async () => {
@@ -107,7 +106,6 @@ const FriendsList = ({setIsInfoOn, setData} : any) => {
 										key={index}
 										nickname={""}
 										intra={""}
-										setData={setData}
 										setIsInfoOn={setIsInfoOn} />
 							))
 						: <EmptyText>아직 친구가 한명도 없어요ㅜㅜ</EmptyText>

--- a/src/pages/private/components/FriendsList.tsx
+++ b/src/pages/private/components/FriendsList.tsx
@@ -61,12 +61,14 @@ const DummyFriends: PlayerInfo[] = [
 		nickname: "yoahn",
 		profile_url: "/src/images/hero.png",
 		ladder_score: 1200,
+		is_my_friend: true,
 	},
 	{
 		intra_id: "seonhjeo",
 		nickname: "HOYA",
 		profile_url: "/src/images/hero.png",
 		ladder_score: 1500,
+		is_my_friend: true,
 	},
 ]
 

--- a/src/pages/private/components/FriendsList.tsx
+++ b/src/pages/private/components/FriendsList.tsx
@@ -1,0 +1,121 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import SectionHeader from "../../../components/SectionHeader";
+import { Url } from "../../../constants/Global";
+import { useAuthState } from "../../../context/AuthHooks";
+import PlayerInfo from "../../lobby/components/PlayerInfo";
+import FriendCard from "./FriendCard";
+
+
+const Container = styled.div`
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background: var(--dark-gray);
+`
+
+const FriendsSection = styled.div`
+	flex: 5;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow-x:hidden;
+	overflow-y:scroll;
+	&::-webkit-scrollbar{
+		width: 0.5rem;
+	}
+	&::-webkit-scrollbar-thumb{
+		background-color: var(--yellow);
+		border-radius: 10px;    
+	}
+	&::-webkit-scrollbar-track{
+		background-color: rgba(0,0,0,0);
+	}
+`
+
+const ContentHeader = styled.div`
+	width: 100%;
+	display: block;
+	font-family: SBAggroM;
+	font-size: 1.5rem;
+	padding: 0.5rem;	
+	background: var(--purple);
+	text-shadow: 0 2px 0 black;
+`
+
+const FriendsContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+`
+
+const EmptyText = styled.div`
+	padding: 1rem;
+`
+
+const dummyFriends: PlayerInfo[] = [
+	{
+		intra_id: "yoahn",
+		nickname: "yoahn",
+		profile_url: "/src/images/hero.png",
+		ladder_score: 1200,
+	},
+	{
+		intra_id: "HOYA",
+		nickname: "seonhjeo",
+		profile_url: "/src/images/hero.png",
+		ladder_score: 1500,
+	},
+]
+
+const FriendsList = ({setIsInfoOn, setData} : any) => {
+  let onlineFriends = new Array<PlayerInfo>();
+
+	const { token } = useAuthState();
+
+  const getFriends = async () => {
+		await axios.get(Url + 'user/friends', {
+				headers: { 'token': 'bearer ' + token }
+		}).then(response => {
+			const Friends = response.data;
+			const onlineArray : PlayerInfo[] = [];
+			for (let friend of Friends) {
+				onlineArray.push(friend)
+			}
+		}).catch(error => {
+			console.log('online friends loading failed');
+			onlineFriends = dummyFriends;
+		});
+	}
+
+  useEffect(()=>{
+    getFriends();
+  }, []);
+
+	return (
+		<Container>
+			<SectionHeader color='var(--purple)' title="Welcome to Pong Game World!"/>
+			<ContentHeader>친구목록</ContentHeader>
+			<FriendsSection>
+				<FriendsContainer>
+					{
+						onlineFriends.length > 0 ?
+							onlineFriends.map((item : PlayerInfo, index) => (
+									<FriendCard
+										key={index}
+										nickname={""}
+										intra={""}
+										setData={setData}
+										setIsInfoOn={setIsInfoOn} />
+							))
+						: <EmptyText>아직 친구가 한명도 없어요ㅜㅜ</EmptyText>
+					}
+				</FriendsContainer>
+			</FriendsSection>
+		</Container>
+	);
+}
+
+export default FriendsList;

--- a/src/pages/private/components/FriendsList.tsx
+++ b/src/pages/private/components/FriendsList.tsx
@@ -55,7 +55,7 @@ const EmptyText = styled.div`
 	padding: 1rem;
 `
 
-const dummyFriends: PlayerInfo[] = [
+const DummyFriends: PlayerInfo[] = [
 	{
 		intra_id: "yoahn",
 		nickname: "yoahn",
@@ -63,29 +63,35 @@ const dummyFriends: PlayerInfo[] = [
 		ladder_score: 1200,
 	},
 	{
-		intra_id: "HOYA",
-		nickname: "seonhjeo",
+		intra_id: "seonhjeo",
+		nickname: "HOYA",
 		profile_url: "/src/images/hero.png",
 		ladder_score: 1500,
 	},
 ]
 
-const FriendsList = ({setIsInfoOn} : any) => {
-  let onlineFriends = new Array<PlayerInfo>();
+const FriendsList = ({setIsInfoOn, setInfoIntra} : any) => {
+  const [onlineFriends, setOnlineFriends] = useState<PlayerInfo[]>([]);
 	const { token } = useAuthState();
 
   const getFriends = async () => {
 		await axios.get(Url + 'user/friends', {
-				headers: { 'token': 'bearer ' + token }
+				headers: { 'token': 'bearer ' + token },
+				timeout: 1000,
 		}).then(response => {
 			const Friends = response.data;
 			const onlineArray : PlayerInfo[] = [];
 			for (let friend of Friends) {
-				onlineArray.push(friend)
+				onlineArray.push(friend);
 			}
+			setOnlineFriends([...onlineArray]);
 		}).catch(error => {
-			console.log('online friends loading failed');
-			onlineFriends = dummyFriends;
+			console.error('online friends loading failed');
+			const onlineArray : PlayerInfo[] = [];
+			for (let friend of DummyFriends) {
+				onlineArray.push(friend);
+			}
+			setOnlineFriends([...onlineArray]);
 		});
 	}
 
@@ -100,13 +106,14 @@ const FriendsList = ({setIsInfoOn} : any) => {
 			<FriendsSection>
 				<FriendsContainer>
 					{
-						onlineFriends.length > 0 ?
+						(onlineFriends.length > 0) ?
 							onlineFriends.map((item : PlayerInfo, index) => (
 									<FriendCard
 										key={index}
-										nickname={""}
-										intra={""}
-										setIsInfoOn={setIsInfoOn} />
+										nickname={item.nickname}
+										intra={item.intra_id}
+										setIsInfoOn={setIsInfoOn} 
+										setInfoIntra={setInfoIntra} />
 							))
 						: <EmptyText>아직 친구가 한명도 없어요ㅜㅜ</EmptyText>
 					}

--- a/src/pages/private/components/PrivateGameRoom.tsx
+++ b/src/pages/private/components/PrivateGameRoom.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import SectionHeader from "../../../components/SectionHeader";
-import { PongGame } from "../../game/PongGame";
+import PongGame from "../../game/PongGame";
 import PlayerCard from "../../../components/PlayerCard";
-import PlayerInfo from "./PlayerInfo";
+import SectionHeader from "../../../components/SectionHeader";
+import PlayerInfo from "../../lobby/components/PlayerInfo";
 
 const Container = styled.div`
 	position: relative;
@@ -51,32 +51,6 @@ const Versus = styled.div`
 	line-height: 20vh;
 `;
 
-const SpectatorContainer = styled.div`
-	padding: 0 0.5rem;	
-	grid-area: spectator;
-	position: relative;
-	width: 100%;
-	height: 100%;
-	display: flex;
-  justify-content: flex-start;
-	flex-wrap: wrap;
-	background: var(--light-gray);
-`;
-
-const ContentHeader = styled.div`
-	border-width: 1px;
-	border-style: hidden hidden solid;
-	grid-area: title;
-	width: 100%;
-	display: block;
-	font-family: SBAggroM;
-  height: 60px;
-	font-size: 1.5rem;
-	padding: 1rem;	
-	background: var(--dark-gray);
-	text-shadow: 0 2px 0 black;
-`;
-
 const GameContainer = styled.div`
 	border-width: 1px;
 	border-style: solid hidden hidden hidden;
@@ -87,16 +61,11 @@ const GameContainer = styled.div`
 	height: 100%;
 `;
 
-const GameRoom = ({setLocate, title} : any) => {
+const PrivateGameRoom = ({setLocate, title} : any) => {
   let playerList = new Array<PlayerInfo>();
-	let spectatorList = new Array<PlayerInfo>();
 
-	playerList.push(new PlayerInfo("sunhkim", "mocha-kim", "/src/images/earth.jpg"));
-	playerList.push(new PlayerInfo("yoahn", "yoahn", "/src/images/game.jpg"));
-
-	spectatorList.push(new PlayerInfo("seonhjeo", "seonhjeo", "some link"))
-	spectatorList.push(new PlayerInfo("chanhuil", "chanhuil", "some link"))
-	spectatorList.push(new PlayerInfo("young-ch", "young-ch", "some link"))
+	playerList.push(new PlayerInfo("sunhkim", "mocha-kim", "/src/images/earth.jpg", 1500));
+	playerList.push(new PlayerInfo("yoahn", "yoahn", "/src/images/game.jpg", 1200));
 
 	return (
 		<Container>
@@ -109,14 +78,6 @@ const GameRoom = ({setLocate, title} : any) => {
 					<Versus> vs </Versus>
 					{playerList[1] ? <PlayerCard type="yellow" player={playerList[1]} />: null}
 				</PlayerContainer>
-				<ContentHeader>관전중인 사람들</ContentHeader>
-				<SpectatorContainer>
-					{
-						spectatorList.map((item : PlayerInfo, index) => (
-							<PlayerCard key={index}	 type="spectator" player={item}></PlayerCard>
-						))
-					}
-				</SpectatorContainer>
 			</UserInfoContainer>
 			<GameContainer>
 				<PongGame />
@@ -125,4 +86,4 @@ const GameRoom = ({setLocate, title} : any) => {
 	);
 }
 
-export default GameRoom;
+export default PrivateGameRoom;

--- a/src/pages/private/index.tsx
+++ b/src/pages/private/index.tsx
@@ -33,20 +33,20 @@ const InfoSection = styled.div`
 
 const Private = () => {
 	const [locate, setLocate] = useState("home");
-	const [info, setInfo] = useState(false);
-	const [data, setData] = useState<UserProps | null>(null);
+	const [isInfoOn, setIsInfoOn] = useState(false);
+	const [infoIntra, setInfoIntra] = useState("");
 	const state = useAuthState();
 
 	return (
 		<Wrapper>
 			<Container>
 				<MainSection>
-          {locate === "home" ? <FriendsList setIsInfoOn={() => setInfo(true)} setData={setData}></FriendsList> : null}
-          {locate === "lobby" ? <PrivateGameRoom setLocate={setLocate} title={state.nickname + (data? data.nickname : "undefined")}></PrivateGameRoom> : null}
+          {locate === "home" ? <FriendsList setIsInfoOn={() => setIsInfoOn(true)} /> : null}
+          {locate === "lobby" ? <PrivateGameRoom setLocate={setLocate} title={state.nickname + (infoIntra ? infoIntra : "undefined")} /> : null}
 				</MainSection>
-				{info ? (
+				{isInfoOn ? (
 					<InfoSection>
-						<Info setIsInfoOn={() => setInfo(true)} data={data} />
+						<Info setIsInfoOn={() => setIsInfoOn(true)} intra={infoIntra} />
 					</InfoSection>
 				) : null}
 			</Container>

--- a/src/pages/private/index.tsx
+++ b/src/pages/private/index.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import styled from "styled-components";
+import PrivateGameRoom from "./components/PrivateGameRoom";
+import Info from "../social/components/Info";
+import FriendsList from "./components/FriendsList";
+import { UserProps } from "../profile/UserProps";
+import { useAuthState } from "../../context/AuthHooks";
+
+const Wrapper = styled.div`
+	width: 100vw;
+	height: 100vh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-image: url("/src/images/background.jpg");
+	font-family: NanumSquareL;
+`;
+
+const Container = styled.div`
+	width: 90%;
+	height: 80%;
+	display: flex;
+`;
+
+const MainSection = styled.div`
+	flex: 4;
+	overflow: hidden;
+`;
+
+const InfoSection = styled.div`
+	flex: 2;	
+`;
+
+const Private = () => {
+	const [locate, setLocate] = useState("home");
+	const [info, setInfo] = useState(false);
+	const [data, setData] = useState<UserProps | null>(null);
+	const state = useAuthState();
+
+	return (
+		<Wrapper>
+			<Container>
+				<MainSection>
+          {locate === "home" ? <FriendsList setIsInfoOn={() => setInfo(true)} setData={setData}></FriendsList> : null}
+          {locate === "lobby" ? <PrivateGameRoom setLocate={setLocate} title={state.nickname + (data? data.nickname : "undefined")}></PrivateGameRoom> : null}
+				</MainSection>
+				{info ? (
+					<InfoSection>
+						<Info setIsInfoOn={() => setInfo(true)} data={data} />
+					</InfoSection>
+				) : null}
+			</Container>
+		</Wrapper>
+	);
+};
+
+export default Private;

--- a/src/pages/private/index.tsx
+++ b/src/pages/private/index.tsx
@@ -41,12 +41,12 @@ const Private = () => {
 		<Wrapper>
 			<Container>
 				<MainSection>
-          {locate === "home" ? <FriendsList setIsInfoOn={() => setIsInfoOn(true)} /> : null}
+          {locate === "home" ? <FriendsList setIsInfoOn={() => setIsInfoOn(true)} setInfoIntra={setInfoIntra} /> : null}
           {locate === "lobby" ? <PrivateGameRoom setLocate={setLocate} title={state.nickname + (infoIntra ? infoIntra : "undefined")} /> : null}
 				</MainSection>
 				{isInfoOn ? (
 					<InfoSection>
-						<Info setIsInfoOn={() => setIsInfoOn(true)} intra={infoIntra} />
+						<Info setIsInfoOn={setIsInfoOn} intra={infoIntra} />
 					</InfoSection>
 				) : null}
 			</Container>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -87,6 +87,7 @@ const DummyUserData: UserProps = {
 const Profile = () => {
   const [userData, setUserData] = useState<UserProps>();
   const { token } = useAuthState();
+  
   const getData = async() => {
     await axios.get(Url + 'user/profile', {
       headers: {
@@ -104,7 +105,7 @@ const Profile = () => {
           data.stats,
           data.matching_history));    
     }).catch(error => {
-      alert('user profile loading failed');
+      console.error('user profile loading failed');
       setUserData(DummyUserData);
     });
   }

--- a/src/pages/profile/UserImage.tsx
+++ b/src/pages/profile/UserImage.tsx
@@ -57,7 +57,7 @@ const UserImage = ({profile_url} : {profile_url : string}) => {
       const url = URL.createObjectURL(file);
       setImage(url);
     }).catch(error => {
-      alert('image upload failed');
+      console.error('image upload failed');
     });
   }
 

--- a/src/pages/profile/UserName.tsx
+++ b/src/pages/profile/UserName.tsx
@@ -58,7 +58,7 @@ const UserName = ({name, children}: {name: string, children: any} ) => {
       console.log("set profile name: " + response.status);
       setNickname(name);
     }).catch (error => {
-      alert('image upload failed');
+      console.error('set name failed');
     });
   }
 

--- a/src/pages/profile/UserTfa.tsx
+++ b/src/pages/profile/UserTfa.tsx
@@ -45,7 +45,7 @@ const UserTfa = ({isTfaOn} : {isTfaOn : boolean}) => {
       console.log("set tfa: " + response.status);
 			setTfa(!tfa);
     }).catch(error => {
-      alert('two factor setting failed');
+      console.error('two factor setting failed');
     });
   }
 

--- a/src/pages/social/components/ChatCard.tsx
+++ b/src/pages/social/components/ChatCard.tsx
@@ -1,7 +1,5 @@
 import axios from "axios";
-import { useEffect, useState } from "react";
 import styled from "styled-components";
-import Avatar from "../../../components/Avatar";
 import { Url } from "../../../constants/Global";
 import { useAuthState } from "../../../context/AuthHooks";
 import { UserProps } from "../../profile/UserProps";
@@ -42,36 +40,20 @@ const TimeBar = styled.div`
   align-self: flex-end;
 `;
 
-const ChatCard = ({isMe, message, setIsInfoOn, setData}: {isMe: boolean, message: Message, setIsInfoOn: any, setData: any}) => {
+const ChatCard = ({isMe, message, setIsInfoOn, setInfoIntra}: {isMe: boolean, message: Message, setIsInfoOn: any, setInfoIntra: any}) => {
   const { token } = useAuthState();
   
-  const showInfo = async () => {
-    await axios.get(Url + 'user/profile/' + message.intra_id, {
-      headers: {
-        Authorization:"Bearer " + token
-      }
-    }).then(response => {
-      if (response.data) {
-        const data: UserProps = response.data;
-        setData(data);
-        console.log(data);
-        setIsInfoOn(true);
-      } else {
-        console.error('There is no user named ' + message.intra_id);
-        setData(null);
-      }
-    }).catch(error => {
-      alert(message.intra_id + ' profile loading failed');
-    });
+  const onClick = () => {
+    setInfoIntra(message.intra_id);
     setIsInfoOn(true);
   }
-  
+
   return (
     <Container isMe={isMe}>
       {!isMe ? (
         <Sender>
           <UserIconButton
-            onClickButton={showInfo}
+            onClickButton={onClick}
             imgSrc={message.profile_url}
             text={message.nickname ?? "undefined"}
             iconSize="2.5" />

--- a/src/pages/social/components/ChatRoom.tsx
+++ b/src/pages/social/components/ChatRoom.tsx
@@ -106,7 +106,7 @@ const DummyMessages: Message[] = [
   },
 ];
 
-const Chat = ({title, isInfoOn, setIsInfoOn, setData}: {title: string, isInfoOn: boolean, setIsInfoOn: any, setData: any}) => {
+const ChatRoom = ({title, setIsInfoOn, setInfoIntra}: {title: string, setIsInfoOn: any, setInfoIntra: any}) => {
   const [userMessage, setUserMessage] = useState(null);
   const lastChat = useRef<HTMLDivElement>(null);
   const state = useAuthState();
@@ -137,7 +137,7 @@ const Chat = ({title, isInfoOn, setIsInfoOn, setData}: {title: string, isInfoOn:
                 isMe={isMe}
                 message={item}
                 setIsInfoOn={() => setIsInfoOn(true)}
-                setData={setData}
+                setInfoIntra={setInfoIntra}
               ></ChatCard>
             );
           })}
@@ -150,4 +150,4 @@ const Chat = ({title, isInfoOn, setIsInfoOn, setData}: {title: string, isInfoOn:
   );
 };
 
-export default Chat;
+export default ChatRoom;

--- a/src/pages/social/components/Info.tsx
+++ b/src/pages/social/components/Info.tsx
@@ -45,6 +45,7 @@ const dummyUserData: PlayerInfo = {
   nickname: 'undefined',
   profile_url: '/src/images/hero.png',
   ladder_score: 1500,
+	is_my_friend: false,
 }
 
 const Info = ({setIsInfoOn, intra}: {setIsInfoOn: any, intra: string}) => {
@@ -65,6 +66,7 @@ const Info = ({setIsInfoOn, intra}: {setIsInfoOn: any, intra: string}) => {
           data.nickname,
           data.profile_url,
 					data.ladder_score,
+					data.is_my_friend,
 				))
     }).catch(error => {
       console.error(intra + ' profile loading failed');
@@ -88,6 +90,7 @@ const Info = ({setIsInfoOn, intra}: {setIsInfoOn: any, intra: string}) => {
 	const onClickBlock = () => {
 		console.log("onClickBlock");
 	}
+
 	return (
 		<Container>
 			<SectionHeader color='var(--purple)'>
@@ -101,7 +104,11 @@ const Info = ({setIsInfoOn, intra}: {setIsInfoOn: any, intra: string}) => {
 				<p>🎖️ {userData ? userData.ladder_score : "???"}</p>
 			</ProfileSection>
 			<IconSection>
-				<IconButton onClickButton={onClickAdd} icon="❤️" text="친구추가" />
+				{
+					userData?.is_my_friend ? 
+						<IconButton onClickButton={onClickAdd} icon="❤️" text="친구추가" />
+						: <IconButton onClickButton={onClickAdd} icon="♡" text="친구삭제" />
+				}
 				<IconButton onClickButton={onClickPlay} icon="🎮" text="게임" />
 				<IconButton onClickButton={onClickBlock} icon="❌" text="차단" />
 			</IconSection>

--- a/src/pages/social/components/Info.tsx
+++ b/src/pages/social/components/Info.tsx
@@ -1,6 +1,11 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import Avatar from "../../../components/Avatar";
 import SectionHeader from "../../../components/SectionHeader";
+import { Url } from "../../../constants/Global";
+import { useAuthState } from "../../../context/AuthHooks";
+import PlayerInfo from "../../lobby/components/PlayerInfo";
 import { UserProps } from "../../profile/UserProps"
 import IconButton from "./IconButton";
 
@@ -35,7 +40,42 @@ const IconSection = styled.div`
 	align-items: center;
 `
 
-const Info = ({setIsInfoOn, data}: {setIsInfoOn: any, data: UserProps | null}) => {
+const dummyUserData: PlayerInfo = {
+  intra_id: 'undefined',
+  nickname: 'undefined',
+  profile_url: '/src/images/hero.png',
+  ladder_score: 1500,
+}
+
+const Info = ({setIsInfoOn, intra}: {setIsInfoOn: any, intra: string}) => {
+  const [userData, setUserData] = useState<PlayerInfo>();
+  const { token } = useAuthState();
+  
+  const getData = async() => {
+    await axios.get(Url + 'user/profile/' + intra, {
+      headers: {
+        Authorization:"Bearer " + token
+      }
+    }).then(response => {
+      const data: PlayerInfo = response.data;
+      console.log(data);
+      setUserData(
+        prev => prev = new PlayerInfo(
+          data.intra_id,
+          data.nickname,
+          data.profile_url,
+					data.ladder_score,
+				))
+    }).catch(error => {
+      console.error(intra + ' profile loading failed');
+      setUserData(dummyUserData);
+    });
+  }
+
+  useEffect(() => {
+		console.log("info on");
+    getData();
+  }, [intra]);
 
 	const onClickAdd = () => {
 		console.log("onClickAdd");
@@ -55,10 +95,11 @@ const Info = ({setIsInfoOn, data}: {setIsInfoOn: any, data: UserProps | null}) =
 				<div>Q</div>
 			</SectionHeader>
 			<ProfileSection>
-				<Avatar.img size="5" src={data?.profile_url} />
+				<Avatar.img size="5" src={userData?.profile_url} />
 				<br></br>
-				<p>{data ? data.nickname : "undefined"}</p>
-				<p>🎖️ {data ? data.stats.ladder_score : "???"}</p>
+				<p>{userData ? userData.nickname : "undefined"}</p>
+				<p>{intra}</p>
+				<p>🎖️ {userData ? userData.ladder_score : "???"}</p>
 			</ProfileSection>
 			<IconSection>
 				<IconButton onClickButton={onClickAdd} icon="❤️" text="친구추가" />

--- a/src/pages/social/components/Info.tsx
+++ b/src/pages/social/components/Info.tsx
@@ -92,7 +92,6 @@ const Info = ({setIsInfoOn, intra}: {setIsInfoOn: any, intra: string}) => {
 		<Container>
 			<SectionHeader color='var(--purple)'>
 				<div onClick={()=>setIsInfoOn(false)}>{"<<"}</div>
-				<div>Q</div>
 			</SectionHeader>
 			<ProfileSection>
 				<Avatar.img size="5" src={userData?.profile_url} />

--- a/src/pages/social/components/Nav.tsx
+++ b/src/pages/social/components/Nav.tsx
@@ -39,9 +39,10 @@ const Button = styled.div`
 	}
 `
 
-const Nav = ({isInfoOn, setLocate, setIsListOn, setIsInfoOn, setData}: {isInfoOn: boolean, setLocate: any, setIsListOn: any, setIsInfoOn: any, setData: any}) => {
+const Nav = ({setLocate, setIsListOn, setIsInfoOn, setInfoIntra}: {setLocate: any, setIsListOn: any, setIsInfoOn: any, setInfoIntra: any}) => {
   const [image, setimage] = useState("");
   const { token } = useAuthState();
+	const state = useAuthState();
 	
   const getData = async() => {
     await axios.get(Url + 'user/profile', {
@@ -58,26 +59,12 @@ const Nav = ({isInfoOn, setLocate, setIsListOn, setIsInfoOn, setData}: {isInfoOn
 	useEffect(() => {
 		getData();
 	}, []);
-
-  const showInfo = async () => {
-    await axios.get(Url + 'user/profile', {
-      headers: {
-        Authorization:"Bearer " + token
-      }
-    }).then(response => {
-      if (response.data) {
-        const data: UserProps = response.data;
-        setData(data);
-        setIsInfoOn(true);
-      } else {
-        console.error('There is no user data');
-        setData(null);
-      }
-    }).catch(error => {
-      console.error('user profile loading failed');
-    });
-  }
 	
+  const onClick = () => {
+    setInfoIntra(state.intra ?? "undefined");
+    setIsInfoOn(true);
+  }
+
 	return (
 			<Container>
 				LOGO
@@ -87,7 +74,7 @@ const Nav = ({isInfoOn, setLocate, setIsListOn, setIsInfoOn, setData}: {isInfoOn
 					<Button onClick={()=>{setIsListOn(true);}}>🤫</Button>
 				</IconSection>
 				<p>you</p>
-				<UserIconButton onClickButton={showInfo} imgSrc={image} text="" iconSize="3" />
+				<UserIconButton onClickButton={onClick} imgSrc={image} text={state.nickname} iconSize="3" />
 			</Container>
 	)
 }

--- a/src/pages/social/components/UserIconButton.tsx
+++ b/src/pages/social/components/UserIconButton.tsx
@@ -17,7 +17,7 @@ const Text = styled.div`
 	margin: 0.5rem;
 `;
 
-const UserIconButton = ({onClickButton, imgSrc, text, iconSize} : {onClickButton: any, imgSrc: string, text: string, iconSize: string}) => {
+const UserIconButton = ({onClickButton, imgSrc, text, iconSize} : {onClickButton: any, imgSrc: string, text: string | undefined, iconSize: string}) => {
 	return (
 		<Wrapper>
 			<Button onClick={onClickButton}>

--- a/src/pages/social/index.tsx
+++ b/src/pages/social/index.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import Nav from "./components/Nav";
 import Info from "./components/Info";
-import Chat from "./components/ChatRoom";
+import ChatRoom from "./components/ChatRoom";
 import Home from "./components/Home";
 import List from "./components/List";
 import { useState } from "react";
@@ -43,7 +43,7 @@ const ListSection = styled.div`
 const Social = () => {
   const [locate, setLocate] = useState("home");
   const [title, setTitle] = useState("");
-  const [data, setData] = useState(null);
+  const [infoIntra, setInfoIntra] = useState("");
   const [isInfoOn, setIsInfoOn] = useState(false);
   const [isListOn, setIsListOn] = useState(false);
 
@@ -51,20 +51,33 @@ const Social = () => {
     <Wrapper>
       <Container>
         <NavSection>
-          <Nav isInfoOn={isInfoOn} setLocate={setLocate} setIsListOn={setIsListOn} setIsInfoOn={setIsInfoOn} setData={setData}/>
+          <Nav
+            setLocate={setLocate}
+            setIsListOn={setIsListOn}
+            setIsInfoOn={setIsInfoOn}
+            setInfoIntra={setInfoIntra}/>
         </NavSection>
         {isListOn ? (
           <ListSection>
-            <List setIsListOn={setIsListOn} setLocate={setLocate}/>
+            <List
+              setIsListOn={setIsListOn}
+              setLocate={setLocate}/>
           </ListSection>
         ) : null}
         <MainSection>
-          {locate === "home" ? <Home setLocate={setLocate} setTitle={setTitle}></Home> : null}
-          {locate === "chat" ? <Chat title={title} isInfoOn={isInfoOn} setIsInfoOn={setIsInfoOn} setData={setData}></Chat> : null}
+          {locate === "home" ?
+            <Home
+              setLocate={setLocate}
+              setTitle={setTitle} /> : null}
+          {locate === "chat" ?
+            <ChatRoom
+              title={title}
+              setIsInfoOn={setIsInfoOn}
+              setInfoIntra={setInfoIntra} /> : null}
         </MainSection>
         {isInfoOn ? (
           <InfoSection>
-            <Info setIsInfoOn={setIsInfoOn} data={data}/>
+            <Info setIsInfoOn={setIsInfoOn} intra={infoIntra}/>
           </InfoSection>
         ) : null}
       </Container>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -12,6 +12,7 @@ import TFAPage from "../auth/TFAPage";
 import Restrict from "../auth/Restrict";
 import ArcadeGamePage from "../pages/arcade/ArcadeGame";
 import Matching from "../pages/matching/Matching";
+import Private from "../pages/private";
 
 const router = createBrowserRouter([
   {
@@ -48,16 +49,20 @@ const router = createBrowserRouter([
         element: <Home />,
       },
       {
+        path: "profile",
+        element: <Profile />,
+      },
+      {
+        path: "private",
+        element: <Private />,
+      },
+      {
         path: "lobby",
         element: <Lobby />,
       },
       {
         path: "social",
         element: <Social />,
-      },
-      {
-        path: "profile",
-        element: <Profile />,
       },
       {
         path: "game",


### PR DESCRIPTION
프라이빗 매치 전 친구목록을 보여주는 페이지를 만들었습니다.
(PlayerInfo 타입으로 정보를 불러옵니다. 이 타입은 채팅에서 유저 정보를 불러올 때와 같습니다)
유저의 정보를 불러오지 못했을 때 경고를 띄우는 대신, 에러 로그를 찍도록 바꾸었습니다.

유저 아이콘을 클릭했을 때 유저 정보를 요청하는 부분을 버튼 자체가 아닌 인포 페이지로 바꾸었습니다.