### PR TITLE
94 first login page

### DIFF
--- a/src/auth/Auth.tsx
+++ b/src/auth/Auth.tsx
@@ -1,23 +1,24 @@
-import { useEffect, useState } from "react";
-import { useLocation, Navigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useAuthDispatch } from "../context/AuthHooks";
+import { flushSync } from "react-dom";
 
 const Auth = () => {
-  const location = useLocation();
   const dispatch = useAuthDispatch();
-  const [sucess, setSucess] = useState(false);
-  useEffect(()=>{
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
     const idx = location.search.indexOf("?token=");
-    if (idx == -1) setSucess(false); 
-    else {
+    if (idx >= 0) {
       const token = location.search.slice(7);
-      dispatch({type: "LOGIN", payload: token});
-      setSucess(true);
+      flushSync(() => dispatch({ type: "LOGIN", payload: token }));
+      flushSync(() => navigate("/"), { replace: true });
+    } else {
+      navigate("/login", { replace: true });
     }
-  },[]);
-  if (sucess)
-    return <Navigate to="/" replace={true} />;
-  return <Navigate to="/login" replace={true} />;
+  }, []);
+
+  return <></>;
 };
 
 export default Auth;

--- a/src/auth/Init.tsx
+++ b/src/auth/Init.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuthDispatch } from "../context/AuthHooks";
+import { flushSync } from "react-dom";
+
+const Init = () => {
+  const dispatch = useAuthDispatch();
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    const idx = location.search.indexOf("?token=");
+    if (idx >= 0) {
+      const token = location.search.slice(7);
+      flushSync(() => dispatch({ type: "LOGIN", payload: token }));
+      flushSync(() => navigate("/profile"), { replace: true });
+    } else {
+      navigate("/login", { replace: true });
+    }
+  }, []);
+
+  return <></>;
+};
+
+export default Init;

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAuthState } from "../context/AuthHooks";
 
 const RequireAuth = ({ children }: { children: JSX.Element }) => {
   const { token } = useAuthState();
-  const [isAuthorized, setIsAuthorized] = useState(token!==undefined);
+  const navigate = useNavigate();
   useEffect(()=>{
-    setIsAuthorized(token!==undefined);
+    if (token === undefined)
+      navigate("/login", {replace: true});
   },[token]);
-  if (!isAuthorized) return <Navigate to="/login" replace={true} />;
   return children;
 };
 

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -16,6 +16,7 @@ import Matching from "../pages/matching/Matching";
 import Private from "../pages/private";
 import Test from "../pages/Test";
 import GameRoom from "../pages/ingame";
+import Init from "../auth/Init";
 
 const router = createBrowserRouter([
   {
@@ -31,6 +32,14 @@ const router = createBrowserRouter([
     element: (
       <Restrict>
         <Auth />,
+      </Restrict>
+    ),
+  },
+  {
+    path: "/init",
+    element: (
+      <Restrict>
+        <Init />,
       </Restrict>
     ),
   },


### PR DESCRIPTION
최초 로그인 시(회원가입), OAuth 인증 이후 profile 페이지로 리다이렉트 되도록,  `<Init />` 컴포넌트를 구현했습니다.

간단하게 `<Navigate to={path}/>` 부분에서 path만 수정해주면 될 거라고 생각했는데, 잘 안되서 Auth 부분을 전부 고쳤습니다.

분명 코드상으로는,
1. useLocation을 사용해서 redirect url에서 token부분만 slice,
2. AuthContextDispatch로 AuthContext에 token 저장,
3. 프로필 페이지로 이동,

1->2->3 순서로 실행되야 하지만, 콘솔로그를 찍어보니, 1->3->`RequireAuth` 컴포넌트에서 토큰이 확인되지 않아 login페이지로 이동->2->`Restrict` 컴포넌트에서 토큰이 있는데 로그인 관련 페이지로 접속해서 메인 페이지로 이동됐습니다.

그래서 조금 찾아보니 react에서 상태변경은 동기적으로 일어나지 않아서 react18에 업데이트 된 `flushSync` 메서드를 사용해서 동기적으로 일어나야 하는 상태변경을 관리해줘야 한다고 합니다.

이제야 그전에 소켓이나 게임 캔버스가 동기적으로 만들어지지 않았던 이유를 알게되었네요 ㅠ

https://merrily-code.tistory.com/226